### PR TITLE
✨ Implement test logic for reissuing access token key

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,8 @@ const nextConfig = {
             {
                 source: '/api/:slug*',
                 destination:
-                    'http://43.203.8.51:8080/:slug*',
+                    process.env.NEXT_PUBLIC_BASE_URL +
+                    ':slug*',
             },
         ];
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "danum",
             "version": "0.1.0",
             "dependencies": {
+                "js-cookie": "^3.0.5",
                 "jwt-decode": "^4.0.0",
                 "next": "14.2.4",
                 "react": "^18",
@@ -2742,6 +2743,14 @@
             },
             "optionalDependencies": {
                 "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "prepare": "husky && husky install"
     },
     "dependencies": {
+        "js-cookie": "^3.0.5",
         "jwt-decode": "^4.0.0",
         "next": "14.2.4",
         "react": "^18",

--- a/src/app/test/page.jsx
+++ b/src/app/test/page.jsx
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+import CheckAuthButton from '../../components/auth/CheckAuthButton';
+
+export default function Test() {
+    // 서버 측에서 cookies 사용
+    const cookieStore = cookies();
+    const RefreshToken =
+        cookieStore.get('refreshToken')?.value;
+
+    return (
+        <>
+            {/* 클라이언트 컴포넌트에 RefreshToken 전달 */}
+            <CheckAuthButton RefreshToken={RefreshToken} />
+        </>
+    );
+}

--- a/src/components/auth/CheckAuthButton.jsx
+++ b/src/components/auth/CheckAuthButton.jsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { checkAuth } from '../../service/authService';
+
+export default function CheckAuthButton({ RefreshToken }) {
+    const handleAuthCheck = () => {
+        if (RefreshToken) {
+            checkAuth(RefreshToken);
+        } else {
+            console.log('No Refresh Token found');
+        }
+    };
+
+    return (
+        <button onClick={handleAuthCheck}>
+            Check Auth
+        </button>
+    );
+}

--- a/src/service/authService.js
+++ b/src/service/authService.js
@@ -1,8 +1,8 @@
-import { jwtDecode } from "jwt-decode";
+import { jwtDecode } from 'jwt-decode';
 
 export default async function login(email, password) {
-  try {
-    /* 
+    try {
+        /* 
             Endpoint : '/member/login'
             HTTP Method : POST
             Function : login
@@ -10,15 +10,15 @@ export default async function login(email, password) {
                 RequestBody: LoginDto(email: String, 
                     password: String)
         */
-    const res = await fetch("/api/member/login", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password }),
-    });
+        const res = await fetch('/api/member/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password }),
+        });
 
-    if (!res.ok) {
-      throw new Error("Login failed");
-    }
+        if (!res.ok) {
+            throw new Error('Login failed');
+        }
 
         const token = await res.text();
 
@@ -30,5 +30,61 @@ export default async function login(email, password) {
     } catch (err) {
         throw new Error(err.message);
     }
-
 }
+
+// 로그아웃 로직
+
+// Test 로직
+export async function checkAuth(RefreshToken) {
+    try {
+        const res = await fetch('/api/auth/refresh', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${RefreshToken}`,
+            },
+        });
+        const accessToken = await res.text();
+        localStorage.setItem('accessToken', accessToken);
+        console.log(jwtDecode(accessToken));
+    } catch (error) {
+        throw new Error(error.message);
+    }
+}
+
+// RefreshToken을 사용해 AccessToken 갱신
+// export async function checkAuth() {
+//     const cookieStore = cookies();
+//     const RefreshToken =
+//         cookieStore.get('refreshToken')?.value;
+
+//     // Test log
+//     console.log(RefreshToken);
+//     if (!RefreshToken) {
+//         console.log('refreshToken is not exist');
+//     }
+
+//     try {
+//         const res = await fetch('/api', {
+//             method: 'POST',
+//             body: JSON.stringify({ RefreshToken }),
+//             headers: { 'Content-Type': 'application/json' },
+//         });
+
+//         if (res.ok) {
+//             const data = await res.json();
+//         }
+//     } catch {}
+// }
+
+// if (response.ok) {
+//   const data = await response.json();
+//   return { isAuthenticated: true, accessToken: data.accessToken };
+// } else {
+//   return { isAuthenticated: false, accessToken: null };
+// }
+// } catch (error) {
+// console.error('Failed to check auth:', error);
+// return { isAuthenticated: false, accessToken: null };
+// }
+// };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#18 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Update API destination to use NEXT_PUBLIC_BASE_URL environment variable for flexible API endpoint configuration
- Add js-cookie (version 3.0.5) as a dependency in both package-lock.json and package.json
- Add Test and CheckAuthButton components
  - Added src/app/test/page.jsx: imports cookies module from next/headers and renders the CheckAuthButton component
  - Added src/components/auth/CheckAuthButton.jsx: implements logic for checking authentication using the RefreshToken passed as a prop
- Update authService.js
  - Add checkAuth function: sends POST request to '/api/auth/refresh' with RefreshToken in the Authorization header