### PR TITLE
feat: 회원가입 예외 처리 및 오류 핸들링 개선 (이메일/닉네임 중복 처리 추가)

### DIFF
--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -22,6 +22,20 @@ export default function JoinForm() {
     const handleSubmit = async (e) => {
         e.preventDefault();
 
+        // 비밀번호 길이 확인
+        if (password.length <= 8 || password.length >= 16) {
+            setError(
+                '비밀번호는 8자 이상 16자 이하여야 합니다.'
+            );
+            return;
+        }
+
+        // 비밀번호와 비밀번호 확인 일치 여부 확인
+        if (password !== passwordCheck) {
+            setError('비밀번호가 일치하지 않습니다.');
+            return;
+        }
+
         const parsedLatitude = parseFloat(latitude);
         const parsedLongitude = parseFloat(longitude);
 

--- a/src/components/auth/JoinForm.jsx
+++ b/src/components/auth/JoinForm.jsx
@@ -14,6 +14,7 @@ export default function JoinForm() {
     const [name, setName] = useState('');
     const [latitude, setLatitude] = useState(''); // 위도 저장
     const [longitude, setLongitude] = useState(''); // 경도 저장
+    const [error, setError] = useState('');
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -30,9 +31,11 @@ export default function JoinForm() {
                 parsedLatitude, // double 타입으로 변환된 위도
                 parsedLongitude // double 타입으로 변환된 경도
             );
-            console.log(response);
+            if (!response.ok) {
+                setError(response.message);
+            }
         } catch (err) {
-            console.log('회원가입 실패');
+            console.log(err);
         }
     };
 
@@ -100,6 +103,7 @@ export default function JoinForm() {
                 >
                     회원가입
                 </Button>
+                <p style={{ color: 'red' }}>{error}</p>
             </form>
         </>
     );

--- a/src/service/authService.js
+++ b/src/service/authService.js
@@ -103,7 +103,7 @@ export async function join(
             }),
         });
         if (!res.ok) {
-            throw new Error('Join failed');
+            return await res.json(); // 에러 메시지 받기
         }
     } catch (err) {
         throw new Error(err.message);


### PR DESCRIPTION
## #️⃣연관된 이슈

#74

## 📝작업 내용

- [ ] 비밀번호 길이(8자 ~ 16자) 및 비밀번호 확인란 일치 여부 검사.
- [ ] 사용자가 잘못된 정보를 입력한 경우 즉시 피드백 제공.
- [ ] 닉네임 중복: 서버에서 닉네임 중복 오류 발생 시 사용자에게 적절한 오류 메시지 출력.
- [ ] 이메일 중복: 이메일 중복 시도 시 사용자에게 경고 메시지 표시.

