### PR TITLE
65 middleware

### DIFF
--- a/src/app/chat/[roomId]/page.jsx
+++ b/src/app/chat/[roomId]/page.jsx
@@ -23,12 +23,12 @@ export default function ChatRoomPage() {
 
     useEffect(() => {
         loadRoomInfo();
-        console.log('1');
+
         // 500 -> token error
         const socket = new SockJS(
             `/danum-backend/ws-stomp`
         );
-        console.log('2');
+
         stompClient.current = new Client({
             webSocketFactory: () => socket,
             connectHeaders: {

--- a/src/app/chat/page.jsx
+++ b/src/app/chat/page.jsx
@@ -22,7 +22,7 @@ export default function ChatPage() {
     const loadRooms = async () => {
         try {
             const fetchedRooms = await getAllChatRooms();
-            console.log(fetchedRooms);
+
             setRooms(fetchedRooms);
         } catch (error) {
             console.error(
@@ -37,7 +37,7 @@ export default function ChatPage() {
         if (!newRoomName.trim()) return;
         try {
             const newRoom = await createGroupChat(user);
-            console.log(newRoom);
+
             setRooms([...rooms, newRoom]);
             setNewRoomName('');
         } catch (error) {

--- a/src/app/login/page.jsx
+++ b/src/app/login/page.jsx
@@ -1,28 +1,15 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense } from 'react';
 import LoginForm from '../../components/auth/LoginForm';
-import { useAuthStore } from '../../store/authStore';
-import { useRouter } from 'next/navigation';
 
 export default function LoginPage() {
-    const { user } = useAuthStore();
-    const router = useRouter();
-    // const searchParams = useSearchParams();
-    // const redirect = searchParams.get('redirect') || '/';
-
-    useEffect(() => {
-        if (user) {
-            // router.push(redirect);
-            router.push('/');
-        }
-    }, [user, router]);
-
     return (
         <>
             <p>Login</p>
-
-            <LoginForm />
+            <Suspense fallback={<div>Loading...</div>}>
+                <LoginForm />
+            </Suspense>
         </>
     );
 }

--- a/src/app/test/page.jsx
+++ b/src/app/test/page.jsx
@@ -1,74 +1,75 @@
-'use client';
+// 'use client';
 
-import Image from 'next/image';
-import { useState } from 'react';
-import QuillEditor from '../../components/QuillEditor';
-// import { cookies } from 'next/headers';
-// import CheckAuthButton from '../../components/auth/CheckAuthButton';
+// import Image from 'next/image';
+// import { useState } from 'react';
+// import QuillEditor from '../../components/QuillEditor';
+import { cookies } from 'next/headers';
+import CheckAuthButton from '../../components/auth/CheckAuthButton';
 
 export default function Test() {
     // 서버 측에서 cookies 사용
-    // const cookieStore = cookies();
-    // const RefreshToken =
-    //     cookieStore.get('refreshToken')?.value;
+    const cookieStore = cookies();
+    const RefreshToken =
+        cookieStore.get('refreshToken')?.value;
 
     // 이미지 테스트
-    const [previewImg, setPreviewImg] = useState();
+    // const [previewImg, setPreviewImg] = useState();
 
     // 이미지 저장
-    const saveHandler = async () => {
-        if (!previewImg) {
-            return;
-        }
+    // const saveHandler = async () => {
+    //     if (!previewImg) {
+    //         return;
+    //     }
 
-        const formData = new FormData();
-        formData.append('img', previewImg[0]);
+    //     const formData = new FormData();
+    //     formData.append('img', previewImg[0]);
 
-        const result = await fetch('/api/upload', {
-            method: 'POST',
-            body: formData,
-        }).then((res) => res.json());
+    //     const result = await fetch('/api/upload', {
+    //         method: 'POST',
+    //         body: formData,
+    //     }).then((res) => res.json());
 
-        if (result.message === 'OK') {
-            alert('이미지가 저장되었습니다.');
-        }
-    };
+    //     if (result.message === 'OK') {
+    //         alert('이미지가 저장되었습니다.');
+    //     }
+    // };
 
     // 이미지 미리보기
-    const fileHandler = (e) => {
-        const file = e.target.files;
+    // const fileHandler = (e) => {
+    //     const file = e.target.files;
 
-        if (file && file.length > 0) {
-            setPreviewImg(file);
-        }
-    };
+    //     if (file && file.length > 0) {
+    //         setPreviewImg(file);
+    //     }
+    // };
 
     return (
         <>
             {/* 클라이언트 컴포넌트에 RefreshToken 전달 */}
-            {/* <CheckAuthButton RefreshToken={RefreshToken} /> */}
+            <CheckAuthButton RefreshToken={RefreshToken} />
+            {/*
             <div>
                 <form>
-                    {/* 파일 업로드  */}
+
                     <input
-                        type='file'
+                        type="file"
                         onChange={fileHandler}
                     />
 
-                    {/* 이미지 미리보기  */}
+
                     {previewImg && (
                         <Image
                             src={URL.createObjectURL(
                                 previewImg[0]
                             )}
-                            alt='이미지 미리보기'
+                            alt="이미지 미리보기"
                             width={100}
                             height={100}
                         />
                     )}
 
                     <button
-                        type='button'
+                        type="button"
                         onClick={saveHandler}
                     >
                         저장하기
@@ -78,6 +79,7 @@ export default function Test() {
             <div>
                 <QuillEditor />
             </div>
+            */}
         </>
     );
 }

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -5,7 +5,10 @@ import Input from '../common/Input';
 import Button from '../common/Button';
 import { login } from '../../service/authService';
 import { useAuthStore } from '../../store/authStore';
-import { useRouter } from 'next/navigation';
+import {
+    useRouter,
+    useSearchParams,
+} from 'next/navigation';
 
 export default function LoginForm() {
     const [email, setEmail] = useState('');
@@ -13,6 +16,9 @@ export default function LoginForm() {
     const [error, setError] = useState(null);
     const { setAuth } = useAuthStore();
     const router = useRouter();
+    const searchParams = useSearchParams();
+
+    const redirectPath = searchParams.get('from') || '/';
 
     // 로그인 로직 셋팅
     const handleSubmit = async (e) => {
@@ -20,7 +26,6 @@ export default function LoginForm() {
 
         try {
             const { user } = await login(email, password);
-
             const expiration = new Date(
                 user.exp * 1000
             ).toLocaleString();
@@ -30,7 +35,8 @@ export default function LoginForm() {
                 user.role[0].authority,
                 expiration
             );
-            router.push('/');
+            console.log(redirectPath);
+            router.push(redirectPath); // /chat으로 안가짐.
         } catch (err) {
             setError('로그인 실패 : ' + err.message);
         }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import {
+    checkAuth,
+    verifyAccessToken,
+} from './service/authService';
+
+export async function middleware(req) {
+    const cookies = req.cookies;
+    const accessToken = cookies.get('accessToken')?.value;
+    const refreshToken = cookies.get('refreshToken')?.value;
+
+    if (!accessToken) {
+        return redirectToLogin(req);
+    }
+
+    try {
+        const verifyResponse =
+            await verifyAccessToken(accessToken);
+
+        if (!verifyResponse.isExpired) {
+            return NextResponse.next();
+        }
+
+        const refreshResponse =
+            await checkAuth(refreshToken); // error
+
+        if (refreshResponse.ok) {
+            const { accessToken: newAccessToken } =
+                await refreshResponse.json();
+
+            const response = NextResponse.next();
+
+            response.cookies.set(
+                'accessToken',
+                newAccessToken,
+                {
+                    path: '/',
+                }
+            );
+
+            return response;
+        }
+
+        return redirectToLogin(req);
+    } catch (error) {
+        console.error('Auth middleware error:', error);
+        return redirectToLogin(req);
+    }
+}
+
+function redirectToLogin(req) {
+    const loginUrl = new URL('/login', req.url);
+
+    // 로그인 후에 사용자가 어디에서 왔는지 정보를 유지
+    loginUrl.searchParams.set('from', req.nextUrl.pathname);
+
+    return NextResponse.redirect(loginUrl);
+}
+
+export const config = {
+    matcher: ['/chat/:path*', '/mypage/:path*'],
+};

--- a/src/service/chatService.js
+++ b/src/service/chatService.js
@@ -16,7 +16,7 @@ export async function getAllChatRooms() {
             Authorization: `Bearer ${accessToken}`,
         },
     });
-    console.log(res);
+
     if (!res.ok) {
         throw new Error('Failed to fetch chat rooms');
     }
@@ -78,7 +78,6 @@ export async function getChatRoomInfo(roomId) {
             },
         }
     );
-    console.log('chatService.js:46', res);
 
     if (!res.ok) {
         throw new Error('Failed to fetch room info');
@@ -116,7 +115,6 @@ export async function createPrivateChat(targetUserId) {
             }),
         }
     );
-    console.log('chatService.js:70', res);
 
     if (!res.ok) {
         throw new Error(
@@ -146,7 +144,6 @@ export async function getRecentMessages() {
             },
         }
     );
-    console.log(res);
     if (!res.ok) {
         throw new Error('Failed to get recent messages');
     }

--- a/src/service/tokenService.js
+++ b/src/service/tokenService.js
@@ -1,0 +1,11 @@
+export function getAccessToken() {
+    return localStorage.getItem('accessToken');
+}
+
+export function setAccessToken(token) {
+    localStorage.setItem('accessToken', token);
+}
+
+export function removeAccessToken() {
+    localStorage.removeItem('accessToken');
+}

--- a/src/service/tokenService.js
+++ b/src/service/tokenService.js
@@ -1,11 +1,19 @@
+// 쿠키에서 accessToken 가져오기
 export function getAccessToken() {
-    return localStorage.getItem('accessToken');
+    const cookieValue = document.cookie
+        .split('; ')
+        .find((row) => row.startsWith('accessToken='))
+        ?.split('=')[1];
+
+    return cookieValue || null;
 }
 
+// 쿠키에 accessToken 저장하기
 export function setAccessToken(token) {
-    localStorage.setItem('accessToken', token);
+    document.cookie = `accessToken=${token}; path=/; Secure; SameSite=Strict;`;
 }
 
+// 쿠키에서 accessToken 삭제하기
 export function removeAccessToken() {
-    localStorage.removeItem('accessToken');
+    document.cookie = 'accessToken=; Max-Age=0; path=/;';
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#65 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

미들웨어 작업했습니다.
- accessToken은 원래 LocalStorage에서 저장되고 있었습니다. 하지만, Front Server에서 사용해야하는데 사용하지 못하더라고요. 그렇다고 백엔드 로직을 바꾸기엔 due date이 조금 타이트한 감이 있습니다. 그래서 그냥 쿠키에 추가하고 해보려고 합니다. (*이후 사이드이펙트가 굉장히 많을 것으로 예상이 됩니다.)
- Token에 대한 서비스 로직을 구현하였습니다. 
- FrontServer에서 작동되는 서비스 로직들은 `next.config`파일에서 CORS 처리해놓았던 `/danum-backend`로직이 되지 않습니다. 그래서 `${NEXT_~~~}` 로직을 사용하였습니다.
- 미들웨어 로직 작업을 하였습니다. chat 페이지, mypage 페이지 같은 auth 정보가 필요한 곳은 로그인 정보가 필요하게 설정해놓았습니다.

앞으로 사이드 이펙트가 굉장히 많이 코드 관리가 더 어려울 것으로 보입니다. (지금 FrontServer 경험으로 멘탈 너무 공격받음.) 에러가 날 때마다 상세하게 알려주시면 고쳐놓겠습니다.