### PR TITLE
프로필 예외 처리 및 에디터 사진 첨부 방식 수정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,13 +8,18 @@ const nextConfig = {
         ];
     },
 
-    // 이미지 호스트 설정 (S3 버킷)
+    // 이미지 호스트 설정 (S3 버킷과 CloudFront)
     images: {
         remotePatterns: [
             {
                 protocol: 'https',
                 hostname:
                     'danum-bucket.s3.ap-northeast-2.amazonaws.com',
+                pathname: '**',
+            },
+            {
+                protocol: 'https',
+                hostname: 'd1v2wety3l5yaa.cloudfront.net', // CloudFront 도메인 추가
                 pathname: '**',
             },
         ],

--- a/src/app/questions/[questionId]/page.jsx
+++ b/src/app/questions/[questionId]/page.jsx
@@ -178,7 +178,7 @@ export default function QuestionsViewPage() {
             <div>
                 <div
                     className={style.content}
-                    id="quill-viewer"
+                    id='quill-viewer'
                     ref={editorRef}
                     style={{
                         height: 'auto',

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -36,29 +36,29 @@ export default function Header() {
             <div className={styles['header-div']}>
                 <ul className={styles['header-ul']}>
                     <li>
-                        <a href="/">danum</a>
+                        <a href='/'>danum</a>
                     </li>
                     <li className={isActive('/')}>
-                        <Link href="/">홈</Link>
+                        <Link href='/'>홈</Link>
                     </li>
                     <li className={isActive('/villages')}>
-                        <Link href="/villages">
+                        <Link href='/villages'>
                             동네이야기
                         </Link>
                     </li>
                     <li className={isActive('/questions')}>
-                        <Link href="/questions">
+                        <Link href='/questions'>
                             질문이야기
                         </Link>
                     </li>
                     <li className={isActive('/chat')}>
-                        <Link href="/chat">채팅</Link>
+                        <Link href='/chat'>채팅</Link>
                     </li>
                     <li className={isActive('/test')}>
-                        <Link href="/test">테스트</Link>
+                        <Link href='/test'>테스트</Link>
                     </li>
                 </ul>
-                <GetProfile />
+                {hydrated && isLoggedIn && <GetProfile />}
                 <ul className={styles['header-ul']}>
                     <SearchIcon />
                     <AlarmIcon />

--- a/src/components/auth/GetProfile.jsx
+++ b/src/components/auth/GetProfile.jsx
@@ -32,7 +32,7 @@ export default function GetProfile() {
         <div>
             <Image
                 src={profileImage}
-                alt="Profile"
+                alt='Profile'
                 width={30} // Next.js Image 컴포넌트에 필요한 width 속성
                 height={30} // Next.js Image 컴포넌트에 필요한 height 속성
                 style={{

--- a/src/components/question/QuestionItem.jsx
+++ b/src/components/question/QuestionItem.jsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import style from './QuestionItem.module.css';
+import Image from 'next/image';
 
 export default function QuestionItem({
     question_id,
@@ -77,7 +78,15 @@ export default function QuestionItem({
 
                 <div className={style.info}>
                     <span className={style.profile}>
-                        <img src={author.profileImageUrl} />
+                        <Image
+                            src={
+                                author?.profileImageUrl ||
+                                '/danum-logo.png'
+                            } // Fallback to default image
+                            width={30} // Desired width
+                            height={30} // Desired height
+                            objectFit='cover'
+                        />
                     </span>
                     <span className={style.userName}>
                         {author.userName}

--- a/src/components/question/QuestionItem.jsx
+++ b/src/components/question/QuestionItem.jsx
@@ -83,6 +83,7 @@ export default function QuestionItem({
                                 author?.profileImageUrl ||
                                 '/danum-logo.png'
                             } // Fallback to default image
+                            alt='프로필'
                             width={30} // Desired width
                             height={30} // Desired height
                             objectFit='cover'

--- a/src/components/question/QuestionNew.jsx
+++ b/src/components/question/QuestionNew.jsx
@@ -62,16 +62,16 @@ export default function QuestionNew() {
             <form onSubmit={onSubmit}>
                 <div className={style.formRow}>
                     <input
-                        type="text"
-                        id="title"
-                        name="title"
+                        type='text'
+                        id='title'
+                        name='title'
                         value={formData.title}
                         onChange={onChangeData}
                         required
                         className={style.input}
                     />
                     <button
-                        type="submit"
+                        type='submit'
                         className={style.button}
                     >
                         작성

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -146,7 +146,7 @@ export async function checkAuth(RefreshToken) {
 // 프로필 이미지 가져오는 로직
 
 export async function getProfile() {
-    const accessToken = localStorage.getItem('accessToken');
+    const accessToken = getAccessToken();
 
     try {
         const res = await fetch(


### PR DESCRIPTION
<!-- 요청에 맞는 이모지를 골라, 제목과 함께 달아주세요! -->
<!--
🎨	코드의 형식 / 구조를 개선 할 때
📰	새 파일을 만들 때
📝	사소한 코드 또는 언어를 변경할 때
🐎	성능을 향상시킬 때
📚	문서를 쓸 때
🐛	버그 reporting할 때, @FIXME 주석 태그 삽입
🚑	버그를 고칠 때
🔥	코드 또는 파일 제거할 때 , @CHANGED주석 태그와 함께
🚜	파일 구조를 변경할 때 . 🎨과 함께 사용
🔨	코드를 리팩토링 할 때
💄	UI / style 개선시
♿️	접근성을 향상시킬 때
🚧	WIP (진행중인 작업)에 커밋, @REVIEW주석 태그와 함께 사용
💎	New Release
🔖	버전 태그
✨	새로운 기능을 소개 할 때
⚡️	도입 할 때 이전 버전과 호환되지 않는 특징, @CHANGED주석 태그 사용
💡	새로운 아이디어, @IDEA주석 태그
🚀	배포 / 개발 작업 과 관련된 모든 것
-->

## #️⃣연관된 이슈
#96 

## 📝작업 내용
 - 로그인 전 후 프로필 사진 표시 예외 처리
 - 게시글 작성자의 프로필 사진 가져오는 토큰 local -> cookie로 변경
 - quill 에디터에서 버킷으로 사진이 저장되도록 수정(이상한 곳으로 저장되고 있었음)
 - cloudfront를 다시 적용해보았습니다. 경과를 지켜봐야 알 수 있을 거 같습니다. (cloudfront지표는 잘 올라갑니다.)
 
 ## 📷첨부파일
 
<img width="684" alt="스크린샷 2024-10-13 17 51 24" src="https://github.com/user-attachments/assets/e0298fad-4981-4094-a4d2-2eb757f4b903">
<img width="1399" alt="스크린샷 2024-10-13 17 53 21" src="https://github.com/user-attachments/assets/cee67036-e9bc-4081-9df7-24529c048e2c">
